### PR TITLE
Use `bool` instead of `Enable` enum

### DIFF
--- a/examples/charBlock/charBlock.zig
+++ b/examples/charBlock/charBlock.zig
@@ -77,9 +77,9 @@ pub export fn main() void {
     initMaps();
 
     display.ctrl.* = .{
-        .bg0 = .enable,
-        .bg1 = .enable,
-        .obj = .enable,
+        .bg0 = true,
+        .bg1 = true,
+        .obj = true,
     };
 
     bg.ctrl[0] = .{

--- a/examples/debugPrint/debugPrint.zig
+++ b/examples/debugPrint/debugPrint.zig
@@ -7,7 +7,7 @@ export var header linksection(".gbaheader") = gba.Header.init("DEBUGPRINT", "ADP
 pub export fn main() void {
     display.ctrl.* = .{
         .mode = .mode3,
-        .bg2 = .enable,
+        .bg2 = true,
     };
 
     debug.init();

--- a/examples/first/first.zig
+++ b/examples/first/first.zig
@@ -7,7 +7,7 @@ export var header linksection(".gbaheader") = gba.Header.init("FIRST", "AFSE", "
 pub export fn main() void {
     gba.display.ctrl.* = .{
         .mode = .mode3,
-        .bg2 = .enable,
+        .bg2 = true,
     };
 
     Mode3.setPixel(120, 80, Color.rgb(31, 0, 0));

--- a/examples/jesuMusic/jesuMusic.zig
+++ b/examples/jesuMusic/jesuMusic.zig
@@ -1,5 +1,4 @@
 const gba = @import("gba");
-const Enable = gba.utils.Enable;
 
 export const gameHeader linksection(".gbaheader") = gba.Header.init("JESUMUSIC", "AJME", "00", 0);
 
@@ -791,20 +790,20 @@ pub export fn main() void {
 
     // Initialize sound registers to allow playback.
     gba.sound.status.* = gba.sound.Status{
-        .pulse_1 = .enable,
-        .pulse_2 = .enable,
-        .noise = .enable,
-        .master = .enable,
+        .pulse_1 = true,
+        .pulse_2 = true,
+        .noise = true,
+        .master = true,
     };
     gba.sound.dmg.* = gba.sound.Dmg{
         .left_volume = 0x7,
         .right_volume = 0x7,
-        .left_pulse_1 = .enable,
-        .left_pulse_2 = .enable,
-        .left_noise = .enable,
-        .right_pulse_1 = .enable,
-        .right_pulse_2 = .enable,
-        .right_noise = .enable,
+        .left_pulse_1 = true,
+        .left_pulse_2 = true,
+        .left_noise = true,
+        .right_pulse_1 = true,
+        .right_pulse_2 = true,
+        .right_noise = true,
     };
     gba.sound.bias.* = gba.sound.Bias{
         .cycle = .bits_6,
@@ -824,7 +823,7 @@ pub export fn main() void {
     gba.bg.palette.banks[2][2] = .rgb(31, 31, 31);
     gba.display.memcpyCharBlock(0, 0, &charset_data);
     gba.display.ctrl.* = gba.display.Control{
-        .bg0 = .enable,
+        .bg0 = true,
     };
 
     var playing: bool = false;

--- a/examples/keydemo/keydemo.zig
+++ b/examples/keydemo/keydemo.zig
@@ -14,7 +14,7 @@ fn loadImageData() void {
 pub export fn main() void {
     display.ctrl.* = .{
         .mode = .mode4,
-        .bg2 = .enable,
+        .bg2 = true,
     };
 
     loadImageData();

--- a/examples/mode3draw/mode3draw.zig
+++ b/examples/mode3draw/mode3draw.zig
@@ -8,7 +8,7 @@ export var header linksection(".gbaheader") = gba.Header.init("MODE3DRAW", "AWJE
 pub export fn main() void {
     display.ctrl.* = .{
         .mode = .mode3,
-        .bg2 = .enable,
+        .bg2 = true,
     };
 
     // Fill screen with grey color

--- a/examples/mode4draw/mode4draw.zig
+++ b/examples/mode4draw/mode4draw.zig
@@ -32,7 +32,7 @@ pub export fn main() void {
 
     display.ctrl.* = .{
         .mode = .mode4,
-        .bg2 = .enable,
+        .bg2 = true,
     };
 
     // Fill screen with grey color

--- a/examples/mode4flip/mode4flip.zig
+++ b/examples/mode4flip/mode4flip.zig
@@ -17,7 +17,7 @@ fn loadImageData() void {
 pub export fn main() void {
     display.ctrl.* = .{
         .mode = .mode4,
-        .bg2 = .enable,
+        .bg2 = true,
     };
 
     loadImageData();

--- a/examples/objAffine/objAffine.zig
+++ b/examples/objAffine/objAffine.zig
@@ -11,8 +11,8 @@ export var header linksection(".gbaheader") = gba.Header.init("OBJAFFINE", "AODE
 pub export fn main() void {
     display.ctrl.* = .{
         .obj_mapping = .one_dimension,
-        .bg0 = .enable,
-        .obj = .enable,
+        .bg0 = true,
+        .obj = true,
     };
 
     debug.init();

--- a/examples/objDemo/objDemo.zig
+++ b/examples/objDemo/objDemo.zig
@@ -15,7 +15,7 @@ fn loadSpriteData() void {
 pub export fn main() void {
     display.ctrl.* = .{
         .obj_mapping = .one_dimension,
-        .obj = .enable,
+        .obj = true,
     };
 
     loadSpriteData();

--- a/examples/screenBlock/screenBlock.zig
+++ b/examples/screenBlock/screenBlock.zig
@@ -48,8 +48,8 @@ fn initMap() void {
 pub export fn main() void {
     initMap();
     display.ctrl.* = .{
-        .bg0 = .enable,
-        .obj = .enable,
+        .bg0 = true,
+        .obj = true,
     };
 
     var x: i10 = 0;

--- a/examples/secondsTimer/secondsTimer.zig
+++ b/examples/secondsTimer/secondsTimer.zig
@@ -76,7 +76,7 @@ fn initMap() void {
 pub export fn main() void {
     initMap();
     display.ctrl.* = display.Control{
-        .bg0 = .enable,
+        .bg0 = true,
     };
 
     // Based on the example here: https://gbadev.net/tonc/timers.html
@@ -88,14 +88,14 @@ pub export fn main() void {
         .counter = @truncate(-0x4000),
         .ctrl = .{
             .freq = .cycles_1024,
-            .enable = .enable,
+            .enable = true,
         },
     };
     timers[2] = Timer{
         .counter = 0,
         .ctrl = .{
             .mode = .cascade,
-            .enable = .enable,
+            .enable = true,
         },
     };
 

--- a/examples/tileDemo/tileDemo.zig
+++ b/examples/tileDemo/tileDemo.zig
@@ -22,7 +22,7 @@ pub export fn main() void {
     };
 
     display.ctrl.* = .{
-        .bg0 = .enable,
+        .bg0 = true,
     };
 
     var x: i10 = 192;

--- a/src/gba/bg.zig
+++ b/src/gba/bg.zig
@@ -1,7 +1,6 @@
 const gba = @import("gba.zig");
 const Color = gba.Color;
 const display = gba.display;
-const Enable = gba.utils.Enable;
 const Priority = display.Priority;
 const math = gba.math;
 const I8_8 = math.I8_8;
@@ -52,7 +51,7 @@ pub const Control = packed struct(u16) {
     /// Unused bits.
     _: u2 = undefined,
     /// Enables mosaic effect. (Makes things appear blocky.)
-    mosaic: Enable = .disable,
+    mosaic: bool = false,
     /// Which format to expect charblock tile data to be in, whether
     /// 4bpp or 8bpp paletted.
     /// Affine backgrounds always use 8bpp.
@@ -68,7 +67,7 @@ pub const Control = packed struct(u16) {
     screen_base_block: u5 = 0,
     /// Whether affine backgrounds should wrap.
     /// Has no effect on normal backgrounds.
-    affine_wrap: Enable = .disable,
+    affine_wrap: bool = false,
     /// Sizes differ depending on whether the background is affine.
     /// Larger sizes use more screenblocks.
     tile_map_size: Size = .{ .normal = .@"32x32" },

--- a/src/gba/bios.zig
+++ b/src/gba/bios.zig
@@ -1,7 +1,6 @@
 const std = @import("std");
 const bufPrint = std.fmt.bufPrint;
 const gba = @import("gba.zig");
-const Enable = gba.utils.Enable;
 const interrupt = gba.interrupt;
 const math = gba.math;
 const I8_8 = math.I8_8;
@@ -168,7 +167,7 @@ pub const DecompressionHeader = packed struct(u32) {
 
 pub const SoundDriverModeArgs = packed struct(u32) {
     reverb_value: u7 = 0,
-    reverb: Enable,
+    reverb: bool = false,
     simultaneous_channels: u4 = 8,
     master_volume: u4 = 15,
     frequency: enum(u4) {

--- a/src/gba/display.zig
+++ b/src/gba/display.zig
@@ -3,7 +3,6 @@ const gba = @import("gba.zig");
 pub const window = @import("window.zig");
 const Color = gba.Color;
 const display = @This();
-const Enable = gba.utils.Enable;
 const U1_4 = gba.math.FixedPoint(.unsigned, 1, 4);
 
 var current_page_addr: u32 = gba.mem.vram;
@@ -90,17 +89,17 @@ pub const Control = packed struct(u16) {
     /// Read only, should stay false
     gbc_mode: bool = false,
     page_select: u1 = 0,
-    oam_access_in_hblank: Enable = .disable,
+    oam_access_in_hblank: bool = false,
     obj_mapping: ObjMapping = .two_dimensions,
     force_blank: bool = false,
-    bg0: Enable = .disable,
-    bg1: Enable = .disable,
-    bg2: Enable = .disable,
-    bg3: Enable = .disable,
-    obj: Enable = .disable,
-    window_0: Enable = .disable,
-    window_1: Enable = .disable,
-    window_obj: Enable = .disable,
+    bg0: bool = false,
+    bg1: bool = false,
+    bg2: bool = false,
+    bg3: bool = false,
+    obj: bool = false,
+    window_0: bool = false,
+    window_1: bool = false,
+    window_obj: bool = false,
 };
 
 /// Display Control Register
@@ -120,9 +119,9 @@ pub const Status = packed struct(u16) {
     h_refresh: RefreshState,
     /// Read only
     vcount_triggered: bool,
-    vblank_irq: Enable = .disable,
-    hblank_irq: Enable = .disable,
-    vcount_trigger: Enable = .disable,
+    vblank_irq: bool = false,
+    hblank_irq: bool = false,
+    vcount_trigger: bool = false,
     _: u2 = 0,
     vcount_trigger_at: u8 = 0,
 };
@@ -161,12 +160,12 @@ pub const mosaic: *volatile Mosaic = @ptrFromInt(gba.mem.io + 0x4C);
 
 pub const Blend = packed struct {
     pub const Layers = packed struct(u6) {
-        bg0: Enable = .disable,
-        bg1: Enable = .disable,
-        bg2: Enable = .disable,
-        bg3: Enable = .disable,
-        obj: Enable = .disable,
-        backdrop: Enable = .disable,
+        bg0: bool = false,
+        bg1: bool = false,
+        bg2: bool = false,
+        bg3: bool = false,
+        obj: bool = false,
+        backdrop: bool = false,
     };
 
     pub const Mode = enum(u2) {

--- a/src/gba/gamepak.zig
+++ b/src/gba/gamepak.zig
@@ -1,6 +1,7 @@
 const gba = @import("gba.zig");
 
-/// Up to 32MB of addressable ROM
+/// Up to 32MB of addressable ROM.
+/// Some games use bank switching to achieve larger sizes.
 pub const Rom = [0x02000000]u8;
 
 /// Gamepak ROM is mirrored 3 times, using different access timings as controlled by `access_timings`:
@@ -50,7 +51,7 @@ const WaitStateControl = packed struct(u16) {
         @"16.78MHz" = 3,
     } = .disable,
     _: u1 = 0,
-    prefetch: gba.Enable = .disable,
+    prefetch: bool = false,
     /// Read-only
     cgb_mode: bool = false,
 };

--- a/src/gba/interrupt.zig
+++ b/src/gba/interrupt.zig
@@ -1,6 +1,5 @@
 const std = @import("std");
 const gba = @import("gba.zig");
-const Enable = gba.utils.Enable;
 const interrupt = @This();
 
 pub const ctrl: *volatile interrupt.Control = @ptrFromInt(gba.mem.io + 0x200);
@@ -42,7 +41,7 @@ pub const Control = extern struct {
     /// the `acknowledge` method exists for this purpose.
     irq_ack: Flags align(2),
     /// Must be enabled for interrupts specified in `triggers` to activate.
-    master: Enable align(4),
+    master: bool align(4),
 
     /// Acknowledges only the given interrupt, without ignoring others.
     pub fn acknowledge(self: *Control, flag: Flag) void {

--- a/src/gba/mem.zig
+++ b/src/gba/mem.zig
@@ -2,7 +2,6 @@
 
 const isAligned = @import("std").mem.isAligned;
 const gba = @import("gba.zig");
-const Enable = gba.utils.Enable;
 
 // TODO: Maybe make these volatile pointers to u8?
 // Access to base addresses for memory regions. Intended mostly for internal use.
@@ -68,10 +67,10 @@ pub const Dma = packed struct {
         dma_repeat: bool = false,
         transfer_type: TransferType = .half_word,
         /// DMA3 only
-        gamepak_drq: Enable = .disable,
+        gamepak_drq: bool = false,
         start_timing: StartTiming = .immediate,
-        irq_at_end: Enable = .disable,
-        enabled: Enable = .disable,
+        irq_at_end: bool = false,
+        enabled: bool = false,
     };
 
     /// For DMA 0, can only be internal memory

--- a/src/gba/obj.zig
+++ b/src/gba/obj.zig
@@ -2,7 +2,6 @@
 const std = @import("std");
 const gba = @import("gba.zig");
 const Color = gba.Color;
-const Enable = gba.utils.Enable;
 const I8_8 = gba.math.I8_8;
 const display = gba.display;
 const Priority = display.Priority;
@@ -138,7 +137,7 @@ pub const Obj = packed struct {
     affine_mode: AffineMode = .normal,
     mode: GfxMode = .normal,
     /// Enables mosaic effects on this object
-    mosaic: Enable = .disable,
+    mosaic: bool = false,
     palette_mode: Color.Bpp = .bpp_4,
     /// Used in combination with size, see `setSize`
     shape: Shape = .square,

--- a/src/gba/sound.zig
+++ b/src/gba/sound.zig
@@ -1,6 +1,5 @@
 const std = @import("std");
 const gba = @import("gba.zig");
-const Enable = gba.utils.Enable;
 
 // References:
 // https://problemkaputt.de/gbatek.htm#gbasoundcontroller
@@ -123,7 +122,7 @@ pub const WaveChannelSelect = packed struct(u16) {
     /// to via the REG_WAVE_RAMx registers.
     bank: u1 = 0,
     /// Whether the channel is stopped or playing.
-    playback: Enable = .disable,
+    playback: bool = false,
     /// Unused bits.
     _2: u8 = 0,
 };
@@ -150,9 +149,9 @@ pub const WaveChannelControl = packed struct(u16) {
     /// Playback volume.
     /// This is overridden when force_volume_75 is set.
     volume: Volume = .percent_0,
-    /// When enabled, overrides the previous volume setting and
+    /// When true, overrides the previous volume setting and
     /// sets volume to 75% instead.
-    force_volume_75: Enable = .disable,
+    force_volume_75: bool = false,
 };
 
 /// Represents the contents of the REG_SND3FREQ register.
@@ -239,21 +238,21 @@ pub const Dmg = packed struct(u16) {
     /// Unused bits.
     _2: u1 = 0,
     /// Enable pulse 1 channel for left speaker.
-    left_pulse_1: Enable = .disable,
+    left_pulse_1: bool = false,
     /// Enable pulse 2 channel for left speaker.
-    left_pulse_2: Enable = .disable,
+    left_pulse_2: bool = false,
     /// Enable wave channel for left speaker.
-    left_wave: Enable = .disable,
+    left_wave: bool = false,
     /// Enable noise channel for left speaker.
-    left_noise: Enable = .disable,
+    left_noise: bool = false,
     /// Enable pulse 1 channel for right speaker.
-    right_pulse_1: Enable = .disable,
+    right_pulse_1: bool = false,
     /// Enable pulse 2 channel for right speaker.
-    right_pulse_2: Enable = .disable,
+    right_pulse_2: bool = false,
     /// Enable wave channel for right speaker.
-    right_wave: Enable = .disable,
+    right_wave: bool = false,
     /// Enable noise channel for right speaker.
-    right_noise: Enable = .disable,
+    right_noise: bool = false,
 };
 
 /// Represents the contents of the DirectSound control register.
@@ -285,18 +284,18 @@ pub const DirectSound = packed struct(u16) {
     /// Unused bits.
     _: u4 = 0,
     /// Enable DirectSound A on left speaker.
-    left_a: Enable = .disable,
+    left_a: bool = false,
     /// Enable DirectSound A on right speaker.
-    right_a: Enable = .disable,
+    right_a: bool = false,
     /// Indicates which timer should be used for DirectSound A.
     timer_a: u1 = 0,
     /// FIFO reset for DirectSound A. When using DMA for DirectSound,
     /// this will cause DMA to reset the FIFO buffer after it's used.
     reset_a: bool = false,
     /// Enable DirectSound B on left speaker.
-    left_b: Enable = .disable,
+    left_b: bool = false,
     /// Enable DirectSound B on right speaker.
-    right_b: Enable = .disable,
+    right_b: bool = false,
     /// Indicates which timer should be used for DirectSound B.
     timer_b: u1 = 0,
     /// FIFO reset for DirectSound B. When using DMA for DirectSound,
@@ -306,18 +305,18 @@ pub const DirectSound = packed struct(u16) {
 
 pub const Status = packed struct(u16) {
     /// Whether the Pulse 1 channel should be currently playing.
-    pulse_1: Enable = .disable,
+    pulse_1: bool = false,
     /// Whether the Pulse 2 channel should be currently playing.
-    pulse_2: Enable = .disable,
+    pulse_2: bool = false,
     /// Whether the Wave channel should be currently playing.
-    wave: Enable = .disable,
+    wave: bool = false,
     /// Whether the Noise channel should be currently playing.
-    noise: Enable = .disable,
+    noise: bool = false,
     /// Unused bits.
     _1: u3 = 0,
     /// Master sound enable. Must be set if any sound is to be
     /// heard at all.
-    master: Enable,
+    master: bool,
     /// Unused bits.
     _2: u8 = 0,
 };

--- a/src/gba/timer.zig
+++ b/src/gba/timer.zig
@@ -1,6 +1,5 @@
 const std = @import("std");
 const gba = @import("gba.zig");
-const Enable = gba.utils.Enable;
 
 /// Encapsulates access to REG_TMxD and REG_TMxCNT registers
 /// for controlling and reading one of the GBA's four timers.
@@ -47,9 +46,9 @@ pub const Timer = packed struct(u32) {
         /// Unused bits.
         _: u3 = 0,
         /// Raise an interrupt upon overflow.
-        interrupt: Enable = .disable,
+        interrupt: bool = false,
         /// Enable the timer.
-        enable: Enable = .disable,
+        enable: bool = false,
     };
 
     /// Corresponds to tonc REG_TMxD.

--- a/src/gba/utils.zig
+++ b/src/gba/utils.zig
@@ -1,21 +1,3 @@
-pub const Enable = enum(u1) {
-    disable,
-    enable,
-
-    /// Convenience function for initializing based on a condition
-    pub fn init(value: bool) Enable {
-        return @enumFromInt(@intFromBool(value));
-    }
-
-    pub fn toggle(self: Enable) Enable {
-        return @enumFromInt(@intFromEnum(self) ^ 1);
-    }
-
-    pub fn enabled(self: Enable) bool {
-        return self == .enable;
-    }
-};
-
 /// Ternary primitive
 pub const TriState = enum(i2) {
     minus = -1,

--- a/src/gba/window.zig
+++ b/src/gba/window.zig
@@ -2,7 +2,6 @@
 
 const gba = @import("gba.zig");
 const window = @This();
-const Enable = gba.Enable;
 
 pub const Bounds = extern struct {
     pub const Horizontal = packed struct(u16) {
@@ -24,12 +23,12 @@ pub const Bounds = extern struct {
 pub const bounds: *volatile Bounds = @ptrFromInt(gba.mem.io + 0x40);
 
 pub const Layers = packed struct(u6) {
-    bg0: Enable = .disable,
-    bg1: Enable = .disable,
-    bg2: Enable = .disable,
-    bg3: Enable = .disable,
-    obj: Enable = .disable,
-    color_sfx: Enable = .disable,
+    bg0: bool = false,
+    bg1: bool = false,
+    bg2: bool = false,
+    bg3: bool = false,
+    obj: bool = false,
+    color_sfx: bool = false,
 };
 
 pub const Control = extern struct {


### PR DESCRIPTION
Relates to some earlier discussions e.g. https://github.com/wendigojaeger/ZigGBA/pull/32#pullrequestreview-3002717718

Using an enum makes logical operators more complicated to use, and Zig does not currently have an especially ergonomic/concise way to convert back and forth between `bool` and a `u1` enum. The benefit in readability of code is very small and not worth that tradeoff, so this PR changes the API to use booleans instead.
