### PR TITLE
Small improvement to input.zig docs: Add example code to demonstrate usage

### DIFF
--- a/src/gba/input.zig
+++ b/src/gba/input.zig
@@ -17,7 +17,7 @@
 //!         input.poll();
 //! 
 //!         if(input.startIsJustPressed()) {
-//!             // Do something when the start button is pressed
+//!             // Do something when the start button was just pressed
 //!         }
 //!     }
 //! }

--- a/src/gba/input.zig
+++ b/src/gba/input.zig
@@ -1,5 +1,27 @@
 //! This module provides an API for reading the state of the GBA's
 //! buttons, which are also called "keys".
+//!
+//! Conventional usage of this library would be like so:
+//!
+//! ```zig
+//! const gba = @import("gba.zig");
+//! 
+//! pub export fn main() void {
+//!     // Initialize an object to contain input state.
+//!     var input: gba.input.BufferedKeysState = .{};
+//! 
+//!     while (true) {
+//!         // Wait for the next frame.
+//!         gba.display.naiveVSync();
+//!         // Update the input state object.
+//!         input.poll();
+//! 
+//!         if(input.startIsJustPressed()) {
+//!             // Do something when the start button is pressed
+//!         }
+//!     }
+//! }
+//! ```
 
 const gba = @import("gba.zig");
 


### PR DESCRIPTION
Docs page now looks like this:

<img width="900" height="890" alt="image" src="https://github.com/user-attachments/assets/9dd1de9c-aefa-478f-8605-b547e7b15863" />
